### PR TITLE
Generate page titles dynamically

### DIFF
--- a/web-app/src/store/index.js
+++ b/web-app/src/store/index.js
@@ -36,6 +36,7 @@ export default new Vuex.Store({
 
     setPageTitle(state, title) {
       Vue.set(state, 'pageTitle', title)
+      document.title = `${title} | Weather Station App`
     },
 
     // Restore sensors from a cache

--- a/web-app/src/views/About.vue
+++ b/web-app/src/views/About.vue
@@ -2,18 +2,14 @@
   <v-container>
     <div class="about">
       <h1>This is an about page</h1>
-      <div>
-        <Graph/>
-      </div>
     </div>
   </v-container>
 </template>
 
 <script>
-import Graph from '../components/Graph'
 export default {
-  components: {
-    Graph
+  created() {
+    this.$store.commit('setPageTitle', 'About')
   }
 }
 </script>

--- a/web-app/src/views/Dashboard.vue
+++ b/web-app/src/views/Dashboard.vue
@@ -20,6 +20,9 @@
 
 export default {
   name: 'Home',
-  components: {}
+  components: {},
+  created() {
+    this.$store.commit('setPageTitle', 'Dashboard')
+  }
 }
 </script>

--- a/web-app/src/views/Station.vue
+++ b/web-app/src/views/Station.vue
@@ -38,6 +38,7 @@ export default {
   },
   mounted() {
     if (this.station) {
+      this.$store.commit('setPageTitle', this.station.label)
       // Resolve station sensor data, be it from a cache or the subsequent network request
       this.$store.dispatch('getStationSensors', this.station)
         .then(() => {
@@ -51,6 +52,7 @@ export default {
       // Ensure data is up-to-date by explicitly making a network request
       this.$store.dispatch('fetchStationSensors', this.station)
     } else {
+      this.$store.commit('setPageTitle', 'Error')
       this.stationError = true
     }
   }


### PR DESCRIPTION
In a [previous commit](https://github.com/JTCC-Programming-Club/weather-station/commit/8a0870c40f016eefeff8f66ee8f2292eeed954f3) I added a placeholder page title and stuck a title in the titlebar of the page layout by first setting the page title in the vuex store so it could be read by the layout component.

Now in this pull request I make it so when the page title changes in the vuex store it applies that title to the webpage title too (the name that shows up on the browser tabs) and then went into each view/ file and set the individual page titles.