### PR TITLE
Add Fahrenheit conversion; Consolidate props

### DIFF
--- a/web-app/src/components/CardContainer.vue
+++ b/web-app/src/components/CardContainer.vue
@@ -2,49 +2,42 @@
   <div class="flex-container">
     <v-card
       class="flex-item"
+      elevation="0"
+      outlined
       rounded
-      v-for="sensor in stationSensors"
-      :key="sensor.id"
-    >
+      v-for="sensor in sensors"
+      :key="sensor.id">
       <TemperatureCard
         v-if="sensor.type.label === 'temperature'"
-        :name="sensor.label"
-        :measurements="sensor.measurements"
-        :sensor-type="sensor.type"
+        :sensor="sensor"
+        class="card"
       />
-      <Graph
-        v-else
-        :name="sensor.label"
-        :measurements="sensor.measurements"
-        :sensor-type="sensor.type"
-      />
+      <div v-else class="card">
+        Invalid sensor type!
+      </div>
     </v-card>
   </div>
 </template>
 
 <script>
-import Graph from './Graph'
 import TemperatureCard from './cards/Temperature'
+
 export default {
   components: {
-    Graph,
     TemperatureCard
   },
   props: {
-    station: {
-      required: true,
-      type: Object
-    },
     sensors: {
       required: true,
-      type: Object
+      type: Array
     }
   },
-  computed: {
-    stationSensors() {
-      return this.station.sensors
-        .map(s => this.sensors[s.id])
-        .filter(s => s)
+  methods: {
+    changeMode(sensorId, mode) {
+      this.$emit('change-mode', { sensorId, mode })
+    },
+    changeTimeAgo(sensorId, timeAgo) {
+      this.$emit('change-time-ago', { sensorId, timeAgo })
     }
   }
 }
@@ -56,21 +49,26 @@ export default {
   flex-flow: row wrap;
   justify-content: space-around;
 }
+
 .flex-item {
   flex-basis: 25%;
   flex-grow: 0.35;
   flex-shrink: 0;
-  margin-bottom: 2px;
-  margin-top: 2px;
   min-height: 20em;
   width: 25%;
 }
+
+.flex-item:first-child {
+  margin-top: 2px;
+}
+
 @media screen and (max-width: 1800px) {
   .flex-item {
     flex-basis: 33.33%;
     width: 33.33%;
   }
 }
+
 @media screen and (max-width: 860px) {
   .flex-item {
     flex-basis: 50%;
@@ -80,9 +78,11 @@ export default {
 @media screen and (max-width: 640px) {
   .flex-item {
     flex-basis: 100%;
+    min-height: 120px;
     width: 100%;
   }
 }
+
 /deep/ .bookmark-button {
   bottom: 0;
   display: none;
@@ -92,10 +92,17 @@ export default {
   right: 0;
   z-index: 1;
 }
-/deep/ .card-container {
+
+.card {
   height: 100%;
 }
-/deep/ .card-container:hover .bookmark-button {
+
+/deep/ .card:hover .bookmark-button {
   display: block;
+}
+
+@media screen and (max-width: 640px) {
+  .card {
+  }
 }
 </style>

--- a/web-app/src/components/Graph.vue
+++ b/web-app/src/components/Graph.vue
@@ -1,5 +1,6 @@
 <template>
   <VueApexCharts
+    class="chart"
     ref="chart"
     height="100%"
     :type="chartType"
@@ -11,6 +12,7 @@
 <script>
 import objectAssignDeep from 'object-assign-deep'
 import VueApexCharts from 'vue-apexcharts'
+
 export default {
   components: {
     VueApexCharts
@@ -33,10 +35,6 @@ export default {
       type: Object,
       required: false,
       default: () => ({})
-    },
-    sensorType: {
-      type: Object,
-      required: true
     }
   },
   computed: {
@@ -81,12 +79,6 @@ export default {
           curve: 'straight',
           width: 2
         },
-        title: {
-          align: 'center',
-          offsetY: 20,
-          size: '2.2em',
-          text: this.sensorType.label
-        },
         tooltip: {
           enabled: false
         },
@@ -125,3 +117,9 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.chart {
+  padding-top: -14px;
+}
+</style>

--- a/web-app/src/components/TimeButtons.vue
+++ b/web-app/src/components/TimeButtons.vue
@@ -39,4 +39,4 @@ export default {
   right: 2px;
   z-index: 1;
 }
-</style>>
+</style>

--- a/web-app/src/components/cards/Temperature.vue
+++ b/web-app/src/components/cards/Temperature.vue
@@ -1,73 +1,84 @@
 <template>
-  <div class="card-container">
+  <div>
     <ModeButton v-model="mode" />
     <TimeButtons v-model="timeAgo" />
-    <Graph
-      v-if="mode==='chart'"
-      :name="name"
-      :measurements="filteredMeasurements"
-      :sensor-type="sensorType"
-    />
     <CurrentView v-if="mode === 'current' && measurements.length">
       <template v-slot:realtime>{{ currentTemperature }}°</template>
       <template v-slot:average>{{ averageTemperature }}°</template>
     </CurrentView>
+    <Graph
+      v-else
+      :name="sensor.label"
+      :measurements="measurements"
+      :options="chartOptions"
+    />
   </div>
 </template>
 
 <script>
-import TimeButtons from '../TimeButtons'
-import ModeButton from '../ModeButton'
-import Graph from '../Graph'
 import CurrentView from '../CurrentView'
+import Graph from '../Graph'
+import ModeButton from '../ModeButton'
+import TimeButtons from '../TimeButtons'
+
+function toFahrenheit(value) {
+  return Math.round(((value * (9 / 5)) + 32) * 10) / 10
+}
 
 export default {
   components: {
-    TimeButtons,
-    ModeButton,
+    CurrentView,
     Graph,
-    CurrentView
+    ModeButton,
+    TimeButtons
   },
   props: {
-    name: {
-      required: true,
-      type: String
-    },
-    measurements: {
-      required: true,
-      type: Array
-    },
-    sensorType: {
+    sensor: {
       required: true,
       type: Object
     }
   },
   data() {
     return {
+      mode: 'current',
       timeAgo: 1728e5,
-      mode: 'current'
+      zoomedIn: false
     }
   },
   computed: {
-    filteredMeasurements() {
-      const now = new Date().getTime()
-      return this.measurements.filter(m =>
-        now - Math.round(new Date(m.created_at).getTime()) <= this.timeAgo
-      )
+    averageTemperature() {
+      const sum = this.measurements.reduce((acc, el) => acc + Number(el.value), 0)
+      return Math.round((sum / this.measurements.length) * 10) / 10
+    },
+    chartOptions() {
+      const values = this.measurements.map(m => m.value)
+      return {
+        yaxis: {
+          max: Math.max(...values),
+          min: Math.min(...values)
+        }
+      }
     },
     currentTemperature() {
-      return this.measurements[this.measurements.length - 1].value
+      if (this.measurements.length) {
+        return this.measurements[this.measurements.length - 1].value
+      }
+      return 0
     },
-    averageTemperature() {
-      const sum = this.filteredMeasurements.reduce((acc, m) => acc + Number(m.value), 0)
-      return Math.round(sum / this.filteredMeasurements.length * 100) / 100
+    measurements() {
+      let measurements = this.sensor.measurements
+      // Filter down to the specified time range
+      if (this.timeAgo !== Infinity) {
+        const now = new Date().getTime()
+        measurements = measurements
+          .filter(m => now - Math.round(new Date(m.created_at).getTime()) <= this.timeAgo)
+      }
+      // Convert to Fahrenheit
+      return measurements.map(m => ({
+        created_at: m.created_at,
+        value: toFahrenheit(m.value)
+      }))
     }
   }
 }
 </script>
-
-<style scoped>
-.card-container {
-  height: 100%;
-}
-</style>

--- a/web-app/src/store/cache-handler.js
+++ b/web-app/src/store/cache-handler.js
@@ -30,12 +30,12 @@ export default async store => {
         idbstore.put(state.dashboard, 'dashboard')
       })
     },
-    setCardMode: (state, idbstore) => {
+    setSensorMode: (state, idbstore) => {
       idbstore.delete('dashboard').then(() => {
         idbstore.put(state.dashboard, 'dashboard')
       })
     },
-    setCardTimeAgo: (state, idbstore) => {
+    setSensorTimeAgo: (state, idbstore) => {
       idbstore.delete('dashboard').then(() => {
         idbstore.put(state.dashboard, 'dashboard')
       })

--- a/web-app/src/store/index.js
+++ b/web-app/src/store/index.js
@@ -22,11 +22,11 @@ export default new Vuex.Store({
     removeBookmark(state, sensorId) {
       Vue.set(state, 'dashboard', state.dashboard.filter(s => s.id !== sensorId))
     },
-    setCardMode(state, { sensorId, mode }) {
+    setSensorMode(state, { sensorId, mode }) {
       const card = state.dashboard.find(c => c.id === sensorId)
       card.mode = mode
     },
-    setCardTimeAgo(state, { sensorId, timeAgo }) {
+    setSensorTimeAgo(state, { sensorId, timeAgo }) {
       const card = state.dashboard.find(c => c.id === sensorId)
       card.timeAgo = timeAgo
     },

--- a/web-app/src/views/Station.vue
+++ b/web-app/src/views/Station.vue
@@ -6,7 +6,7 @@
     Error loading sensors for {{ station.label }}
   </div>
   <div v-else-if="sensorsLoaded">
-    <StationContainer :station="station" :sensors="sensors" />
+    <CardContainer :sensors="sensors" />
   </div>
   <div v-else>
     Loading sensors...
@@ -14,12 +14,12 @@
 </template>
 
 <script>
-import StationContainer from '@/components/StationContainer'
+import CardContainer from '@/components/CardContainer'
 
 export default {
   name: 'Station',
   components: {
-    StationContainer
+    CardContainer
   },
   data() {
     return {
@@ -30,7 +30,12 @@ export default {
   },
   computed: {
     sensors() {
-      return this.$store.state.sensors
+      if (!this.station) {
+        return []
+      }
+      return this.station.sensors.map(sensor => {
+        return this.$store.state.sensors[sensor.id]
+      })
     },
     station() {
       return this.$store.state.stations.find(station => station.id === this.$route.params.id)


### PR DESCRIPTION
- Rename StationContainer to the more appropriate name CardContainer.
  We'll also use the CardContainer on the Dashboard page so the old name
  would have been confusing.
- Add Fahrenheit conversion for temperature. We can make a toggle switch
  under the preferences later
- Just pass "sensor" into cards instead of all the individual bits of a
  sensor as props
- Remove sensor type title from graph
- Tidy up margin styling