### PR TITLE
Gracefully handle invalid measurement values

### DIFF
--- a/api-server/src/udp.rs
+++ b/api-server/src/udp.rs
@@ -125,8 +125,14 @@ fn parse_message(mut input: &[u8]) -> Result<(&[u8], Message), UdpError> {
         if name == b"id" {
             station_id = String::from_utf8_lossy(&value).to_string();
         } else {
-            let value = BigDecimal::parse_bytes(value, 10).unwrap();
-            values.insert(String::from_utf8_lossy(name).to_string(), value);
+            match BigDecimal::parse_bytes(value, 10) {
+                Some(value) => {
+                    values.insert(String::from_utf8_lossy(name).to_string(), value)
+                },
+                None => {
+                    return Err(UdpError::Custom("Received an invalid measurement value".to_string()));
+                }
+            };
         }
     }
     // Remaining message is crc sum; calculate based on what we've so far


### PR DESCRIPTION
When sending invalid weather station data to the server via UDP the server would sometimes panic. For example you can run the measurements script (using a station id and key from the migrations seed) and the following will successfully record measurements into the database:

```sh
cargo run --bin measurement 127.0.0.1:3381 STATION_ID STATION_KEY air_temp=21,humidity=80
```

The follow message has an extra `=` as part of the air temperature value and won't work. Even worse though, it causes the UDP thread on the server to panic and it never recovers unless you manually restart the server:

```sh
cargo run --bin measurement 127.0.0.1:3381 STATION_ID STATION_KEY air_temp=21=,humidity=80
```

You get the following panic message:

```
thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', src/udp.rs:128:60
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Now try with the fix in place and the invalid message is handled gracefully:

```
[2021-07-11T02:45:38Z WARN  api::udp] dropping invalid message; error was Err(Custom("Received an invalid measurement value"))
```

Try out a few different invalid messages to make sure I'm not missing anything.