### PR TITLE
Fix card z-index

### DIFF
--- a/web-app/src/components/CurrentView.vue
+++ b/web-app/src/components/CurrentView.vue
@@ -79,6 +79,7 @@ export default {
 <style scoped>
 .container {
   height: 100%;
+  z-index: 0;
 }
 
 .text-body {


### PR DESCRIPTION
Now the mode button is no longer behind the card container and you can click it again.