### PR TITLE
Add dashboard edit mode and card sorting

### DIFF
--- a/web-app/src/components/BookmarkButton.vue
+++ b/web-app/src/components/BookmarkButton.vue
@@ -1,7 +1,8 @@
 <template>
-  <div class="bookmark-button">
+  <div class="bookmark-button" :class="{ 'edit-mode': editMode }">
     <v-btn x-small @click="toggleBookmark()">
-      <v-icon v-if="bookmarked">mdi-bookmark-check-outline</v-icon>
+      <v-icon v-if="isDashboard" small>mdi-trash-can-outline</v-icon>
+      <v-icon v-else-if="bookmarked">mdi-bookmark-check-outline</v-icon>
       <v-icon v-else>mdi-bookmark-plus</v-icon>
     </v-btn>
   </div>
@@ -12,6 +13,14 @@ import { mapMutations } from 'vuex'
 
 export default {
   props: {
+    editMode: {
+      required: true,
+      type: Boolean
+    },
+    isDashboard: {
+      required: true,
+      type: Boolean
+    },
     mode: {
       required: true,
       type: String
@@ -63,18 +72,9 @@ export default {
   z-index: 1;
 }
 
-/* Always display the button if this is a touch device */
-@media (pointer: none) {
-  .bookmark-button {
+@media screen and (max-width: 1000px) {
+  .bookmark-button.edit-mode {
     display: block;
   }
 }
-
-/* Backwards compatibility */
-@media (hover: none) {
-  .bookmark-button {
-    display: block;
-  }
-}
-
 </style>

--- a/web-app/src/components/CardContainer.vue
+++ b/web-app/src/components/CardContainer.vue
@@ -149,4 +149,8 @@ export default {
 /deep/ .card:hover .bookmark-button {
   display: block;
 }
+
+/deep/ .card:hover .sort-buttons {
+  display: block;
+}
 </style>

--- a/web-app/src/components/CardContainer.vue
+++ b/web-app/src/components/CardContainer.vue
@@ -10,43 +10,49 @@
     >
       <ElevationCard
         v-if="sensor.type.label === 'elevation'"
+        :edit-mode="editMode"
         :sensor="sensor"
-        @change-mode="changeMode(sensor.id, $event)"
+        @change-mode="changeCardView(sensor.id, $event)"
         @change-time-ago="changeTimeAgo(sensor.id, $event)"
         class="card"
       />
       <HumidityCard
         v-else-if="sensor.type.label === 'humidity'"
+        :edit-mode="editMode"
         :sensor="sensor"
-        @change-mode="changeMode(sensor.id, $event)"
+        @change-mode="changeCardView(sensor.id, $event)"
         @change-time-ago="changeTimeAgo(sensor.id, $event)"
         class="card"
       />
       <PressureCard
         v-else-if="sensor.type.label === 'pressure'"
+        :edit-mode="editMode"
         :sensor="sensor"
-        @change-mode="changeMode(sensor.id, $event)"
+        @change-mode="changeCardView(sensor.id, $event)"
         @change-time-ago="changeTimeAgo(sensor.id, $event)"
         class="card"
       />
       <SignalCard
         v-else-if="sensor.type.label === 'signal'"
+        :edit-mode="editMode"
         :sensor="sensor"
-        @change-mode="changeMode(sensor.id, $event)"
+        @change-mode="changeCardView(sensor.id, $event)"
         @change-time-ago="changeTimeAgo(sensor.id, $event)"
         class="card"
       />
       <TemperatureCard
         v-else-if="sensor.type.label === 'temperature'"
+        :edit-mode="editMode"
         :sensor="sensor"
-        @change-mode="changeMode(sensor.id, $event)"
+        @change-mode="changeCardView(sensor.id, $event)"
         @change-time-ago="changeTimeAgo(sensor.id, $event)"
         class="card"
       />
       <VoltageCard
         v-else-if="sensor.type.label === 'voltage'"
+        :edit-mode="editMode"
         :sensor="sensor"
-        @change-mode="changeMode(sensor.id, $event)"
+        @change-mode="changeCardView(sensor.id, $event)"
         @change-time-ago="changeTimeAgo(sensor.id, $event)"
         class="card"
       />
@@ -75,13 +81,18 @@ export default {
     VoltageCard
   },
   props: {
+    editMode: {
+      default: true,
+      required: false,
+      type: Boolean
+    },
     sensors: {
       required: true,
       type: Array
     }
   },
   methods: {
-    changeMode(sensorId, mode) {
+    changeCardView(sensorId, mode) {
       this.$emit('change-mode', { sensorId, mode })
     },
     changeTimeAgo(sensorId, timeAgo) {
@@ -137,10 +148,5 @@ export default {
 
 /deep/ .card:hover .bookmark-button {
   display: block;
-}
-
-@media screen and (max-width: 640px) {
-  .card {
-  }
 }
 </style>

--- a/web-app/src/components/CardHeader.vue
+++ b/web-app/src/components/CardHeader.vue
@@ -1,16 +1,38 @@
 <template>
-  <div class="header">
+  <div class="header" :class="{ 'edit-mode': editMode }">
     <slot />
   </div>
 </template>
 
+<script>
+export default {
+  props: {
+    editMode: {
+      required: true,
+      type: Boolean
+    }
+  }
+}
+</script>
+
 <style scoped>
+/* Offset to account for buttons when in edit mode */
+.edit-mode {
+  left: 12%;
+}
+
 .header {
   position: absolute;
-  left: 12%;
   font-size: 1.14em;
   font-weight: bold;
   z-index: 1;
   text-shadow: 2px 2px var(--v-text-inverse-base);
 }
-</style>>
+
+/* Buttons are always present on larger screen widths */
+@media screen and not (max-width: 1000px) {
+  .header {
+    left: 12%;
+  }
+}
+</style>

--- a/web-app/src/components/CurrentView.vue
+++ b/web-app/src/components/CurrentView.vue
@@ -85,6 +85,7 @@ export default {
   flex-direction: row;
   flex-wrap: wrap;
   line-height: 1.1;
+  padding-top: 4px;
   position: relative;
   z-index: 1;
 }
@@ -106,6 +107,7 @@ export default {
 }
 
 .sparkline {
+  padding-top: 4px;
   position: absolute;
   z-index: 0;
 }

--- a/web-app/src/components/Layout.vue
+++ b/web-app/src/components/Layout.vue
@@ -15,6 +15,14 @@
 
       <v-spacer></v-spacer>
 
+      <v-app-bar-nav-icon
+        v-if="$route.name === 'dashboard'"
+        class="edit-button"
+        @click="editMode = !editMode">
+        <v-icon v-if="editMode">mdi-lock-open-variant</v-icon>
+        <v-icon v-else>mdi-lock</v-icon>
+      </v-app-bar-nav-icon>
+
       <v-app-bar-nav-icon @click="preferencesDrawerOpen = !preferencesDrawerOpen">
         <v-icon>mdi-cog</v-icon>
       </v-app-bar-nav-icon>
@@ -39,6 +47,14 @@ export default {
     PreferencesDrawer
   },
   computed: {
+    editMode: {
+      get() {
+        return this.$store.state.editMode
+      },
+      set(value) {
+        this.$store.commit('setEditMode', value)
+      }
+    },
     navDrawerOpen: {
       get() {
         return this.$store.state.navDrawer
@@ -58,3 +74,16 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+/* Edit buttons only relevant for overcrowded displays */
+.edit-button {
+  display: none;
+}
+
+@media screen and (max-width: 1000px) {
+  .edit-button {
+    display: block;
+  }
+}
+</style>

--- a/web-app/src/components/ModeButton.vue
+++ b/web-app/src/components/ModeButton.vue
@@ -2,6 +2,7 @@
   <v-btn
     @click="switchMode()"
     class="v-btn-toggle mode-button"
+    :class="{ 'edit-mode': editMode }"
     elevation="0"
     outlined
     x-small
@@ -13,6 +14,10 @@
 <script>
 export default {
   props: {
+    editMode: {
+      required: true,
+      type: Boolean
+    },
     modes: {
       default: () => (['current', 'chart']),
       type: Array
@@ -46,10 +51,15 @@ export default {
 
 <style scoped>
 .mode-button {
+  display: none;
   margin-top: 2px;
   position: absolute;
   left: 2px;
   z-index: 1;
+}
+
+.mode-button.edit-mode {
+  display: block;
 }
 
 .mode-button.theme--light {
@@ -60,4 +70,9 @@ border-color: var(--v-secondary-lighten5);
 border-color: var(--v-secondary-base);
 }
 
+@media screen and not (max-width: 1000px) {
+  .mode-button {
+    display: block;
+  }
+}
 </style>

--- a/web-app/src/components/SortButtons.vue
+++ b/web-app/src/components/SortButtons.vue
@@ -45,10 +45,8 @@ export default {
   z-index: 1;
 }
 
-@media screen and (max-width: 1000px) {
-  .sort-buttons {
-    display: block;
-  }
+.sort-buttons.edit-mode {
+  display: block;
 }
 
 .up-arrow {

--- a/web-app/src/components/SortButtons.vue
+++ b/web-app/src/components/SortButtons.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="sort-buttons" :class="{ 'edit-mode': editMode }">
+    <v-btn x-small @click="moveCard('left')">
+      <v-icon class="up-arrow">mdi-arrow-up-thick</v-icon>
+      <v-icon class="left-arrow">mdi-arrow-left-thick</v-icon>
+    </v-btn>
+    <v-btn x-small @click="moveCard('right')">
+      <v-icon class="down-arrow">mdi-arrow-down-thick</v-icon>
+      <v-icon class="right-arrow">mdi-arrow-right-thick</v-icon>
+    </v-btn>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    editMode: {
+      required: true,
+      type: Boolean
+    },
+    sensorId: {
+      required: true,
+      type: String
+    }
+  },
+  methods: {
+    moveCard(direction) {
+      this.$store.commit('moveSensorCard', {
+        sensorId: this.sensorId,
+        direction
+      })
+    }
+  }
+}
+</script>
+
+<style scoped>
+.sort-buttons {
+  bottom: 0;
+  display: none;
+  left: 0;
+  padding-bottom: 4px;
+  padding-left: 4px;
+  position: absolute;
+  z-index: 1;
+}
+
+@media screen and (max-width: 1000px) {
+  .sort-buttons {
+    display: block;
+  }
+}
+
+.up-arrow {
+  display: none;
+}
+.down-arrow {
+  display: none;
+}
+.left-arrow {
+  display: block;
+}
+.right-arrow {
+  display: block;
+}
+
+/* Display up/down arrows instead on small displays
+   since we're now in a vertical layout. */
+@media screen and (max-width: 640px) {
+  .up-arrow {
+    display: block;
+  }
+  .down-arrow {
+    display: block;
+  }
+  .left-arrow {
+    display: none;
+  }
+  .right-arrow {
+    display: none;
+  }
+}
+</style>

--- a/web-app/src/components/TimeButtons.vue
+++ b/web-app/src/components/TimeButtons.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="time-buttons">
+  <div class="time-buttons" :class="{ 'edit-mode': editMode }">
     <v-btn v-if="zoomedIn" x-small @click="resetZoom()">Reset</v-btn>
     <v-btn-toggle mandatory :value="value" @change="updateValue($event)">
       <v-btn x-small :value="846e5">1d</v-btn>
@@ -15,6 +15,10 @@
 <script>
 export default {
   props: {
+    editMode: {
+      required: true,
+      type: Boolean
+    },
     value: {
       required: true,
       type: Number
@@ -37,9 +41,20 @@ export default {
 
 <style scoped>
 .time-buttons {
+  display: none;
   margin-top: -2px;
   position: absolute;
   right: 2px;
   z-index: 1;
+}
+
+.time-buttons.edit-mode {
+  display: block;
+}
+
+@media screen and not (max-width: 1000px) {
+  .time-buttons {
+    display: block;
+  }
 }
 </style>

--- a/web-app/src/components/cards/Elevation.vue
+++ b/web-app/src/components/cards/Elevation.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <ModeButton
-      :editMode="editMode"
+      :edit-mode="editMode"
       :value="mode"
       @input="setMode"
     />
@@ -12,7 +12,7 @@
       </div>
     </CardHeader>
     <TimeButtons
-      :editMode="editMode"
+      :edit-mode="editMode"
       :value="timeAgo"
       @input="setTimeAgo"
       :zoomed-in="zoomedIn"
@@ -37,9 +37,9 @@
       :zoomed-in="zoomedIn"
       @zoomed-in="zoomedIn = true"
     />
-    <!-- Don't show this on the dashboard -->
     <BookmarkButton
-      v-if="!sensor.settings"
+      :edit-mode="editMode"
+      :is-dashboard="!!sensor.settings"
       :mode="mode"
       :sensor-id="sensor.id"
       :time-ago="timeAgo"

--- a/web-app/src/components/cards/Elevation.vue
+++ b/web-app/src/components/cards/Elevation.vue
@@ -1,13 +1,18 @@
 <template>
   <div>
-    <ModeButton :value="mode" @input="setMode" />
-    <CardHeader>
+    <ModeButton
+      :editMode="editMode"
+      :value="mode"
+      @input="setMode"
+    />
+    <CardHeader :editMode="editMode">
       <div>
         {{ sensor.label }}
         <span v-if="sensor.settings">- {{ sensor.station.label }}</span>
       </div>
     </CardHeader>
     <TimeButtons
+      :editMode="editMode"
       :value="timeAgo"
       @input="setTimeAgo"
       :zoomed-in="zoomedIn"
@@ -60,6 +65,10 @@ export default {
     CardHeader
   },
   props: {
+    editMode: {
+      required: true,
+      type: Boolean
+    },
     sensor: {
       required: true,
       type: Object

--- a/web-app/src/components/cards/Elevation.vue
+++ b/web-app/src/components/cards/Elevation.vue
@@ -37,6 +37,11 @@
       :zoomed-in="zoomedIn"
       @zoomed-in="zoomedIn = true"
     />
+    <SortButtons
+      v-if="sensor.settings"
+      :edit-mode="editMode"
+      :sensor-id="sensor.id"
+    />
     <BookmarkButton
       :edit-mode="editMode"
       :is-dashboard="!!sensor.settings"
@@ -52,6 +57,7 @@ import BookmarkButton from '../BookmarkButton'
 import CurrentView from '../CurrentView'
 import Graph from '../Graph'
 import ModeButton from '../ModeButton'
+import SortButtons from '../SortButtons'
 import TimeButtons from '../TimeButtons'
 import CardHeader from '../CardHeader'
 
@@ -61,6 +67,7 @@ export default {
     CurrentView,
     Graph,
     ModeButton,
+    SortButtons,
     TimeButtons,
     CardHeader
   },

--- a/web-app/src/components/cards/Humidity.vue
+++ b/web-app/src/components/cards/Humidity.vue
@@ -1,13 +1,23 @@
 <template>
   <div>
-    <ModeButton :value="mode" @input="setMode" />
-    <CardHeader>
+    <ModeButton
+      :editMode="editMode"
+      :value="mode"
+      @input="setMode"
+    />
+    <CardHeader :editMode="editMode">
       <div>
         {{ sensor.label }}
         <span v-if="sensor.settings">- {{ sensor.station.label }}</span>
       </div>
     </CardHeader>
-    <TimeButtons :value="timeAgo" @input="setTimeAgo" :zoomed-in="zoomedIn" @reset-zoom="zoomedIn = false" />
+    <TimeButtons
+      :editMode="editMode"
+      :value="timeAgo"
+      @input="setTimeAgo"
+      :zoomed-in="zoomedIn"
+      @reset-zoom="zoomedIn = false"
+    />
     <CurrentView v-if="mode === 'current' && measurements.length" :measurements="measurements">
       <template v-slot:value1>{{ currentHumidity }}%</template>
       <template v-slot:value2>{{ averageHumidity }}%</template>
@@ -45,6 +55,10 @@ export default {
     CardHeader
   },
   props: {
+    editMode: {
+      required: true,
+      type: Boolean
+    },
     sensor: {
       required: true,
       type: Object

--- a/web-app/src/components/cards/Humidity.vue
+++ b/web-app/src/components/cards/Humidity.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <ModeButton
-      :editMode="editMode"
+      :edit-mode="editMode"
       :value="mode"
       @input="setMode"
     />
@@ -12,7 +12,7 @@
       </div>
     </CardHeader>
     <TimeButtons
-      :editMode="editMode"
+      :edit-mode="editMode"
       :value="timeAgo"
       @input="setTimeAgo"
       :zoomed-in="zoomedIn"
@@ -32,8 +32,14 @@
       :measurements="measurements"
       :zoomed-in="zoomedIn"
       @zoomed-in="zoomedIn = true"
-      />
-    <BookmarkButton v-if="!sensor.settings" :mode="mode" :sensor-id="sensor.id" :time-ago="timeAgo" />
+    />
+    <BookmarkButton
+      :edit-mode="editMode"
+      :is-dashboard="!!sensor.settings"
+      :mode="mode"
+      :sensor-id="sensor.id"
+      :time-ago="timeAgo"
+    />
   </div>
 </template>
 

--- a/web-app/src/components/cards/Humidity.vue
+++ b/web-app/src/components/cards/Humidity.vue
@@ -33,6 +33,11 @@
       :zoomed-in="zoomedIn"
       @zoomed-in="zoomedIn = true"
     />
+    <SortButtons
+      v-if="sensor.settings"
+      :edit-mode="editMode"
+      :sensor-id="sensor.id"
+    />
     <BookmarkButton
       :edit-mode="editMode"
       :is-dashboard="!!sensor.settings"
@@ -48,6 +53,7 @@ import BookmarkButton from '../BookmarkButton'
 import CurrentView from '../CurrentView'
 import Graph from '../Graph'
 import ModeButton from '../ModeButton'
+import SortButtons from '../SortButtons'
 import TimeButtons from '../TimeButtons'
 import CardHeader from '../CardHeader'
 
@@ -57,6 +63,7 @@ export default {
     CurrentView,
     Graph,
     ModeButton,
+    SortButtons,
     TimeButtons,
     CardHeader
   },

--- a/web-app/src/components/cards/Pressure.vue
+++ b/web-app/src/components/cards/Pressure.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <ModeButton
-      :editMode="editMode"
+      :edit-mode="editMode"
       :value="mode"
       @input="setMode"
     />
@@ -12,7 +12,7 @@
       </div>
     </CardHeader>
     <TimeButtons
-      :editMode="editMode"
+      :edit-mode="editMode"
       :value="timeAgo"
       @input="setTimeAgo"
       :zoomed-in="zoomedIn"
@@ -33,8 +33,14 @@
       :options="chartOptions"
       :zoomed-in="zoomedIn"
       @zoomed-in="zoomedIn = true"
-      />
-    <BookmarkButton v-if="!sensor.settings" :mode="mode" :sensor-id="sensor.id" :time-ago="timeAgo" />
+    />
+    <BookmarkButton
+      :edit-mode="editMode"
+      :is-dashboard="!!sensor.settings"
+      :mode="mode"
+      :sensor-id="sensor.id"
+      :time-ago="timeAgo"
+    />
   </div>
 </template>
 

--- a/web-app/src/components/cards/Pressure.vue
+++ b/web-app/src/components/cards/Pressure.vue
@@ -1,13 +1,23 @@
 <template>
   <div>
-    <ModeButton :value="mode" @input="setMode" />
-    <CardHeader>
+    <ModeButton
+      :editMode="editMode"
+      :value="mode"
+      @input="setMode"
+    />
+    <CardHeader :editMode="editMode">
       <div>
         {{ sensor.label }}
         <span v-if="sensor.settings">- {{ sensor.station.label }}</span>
       </div>
     </CardHeader>
-    <TimeButtons :value="timeAgo" @input="setTimeAgo" :zoomed-in="zoomedIn" @reset-zoom="zoomedIn = false" />
+    <TimeButtons
+      :editMode="editMode"
+      :value="timeAgo"
+      @input="setTimeAgo"
+      :zoomed-in="zoomedIn"
+      @reset-zoom="zoomedIn = false"
+    />
     <CurrentView v-if="mode === 'current' && measurements.length" :measurements="measurements">
       <template v-slot:value1>{{ currentPressure }}hpa</template>
       <template v-slot:value2>{{ averagePressure }}hpa</template>
@@ -46,6 +56,10 @@ export default {
     CardHeader
   },
   props: {
+    editMode: {
+      required: true,
+      type: Boolean
+    },
     sensor: {
       required: true,
       type: Object

--- a/web-app/src/components/cards/Pressure.vue
+++ b/web-app/src/components/cards/Pressure.vue
@@ -34,6 +34,11 @@
       :zoomed-in="zoomedIn"
       @zoomed-in="zoomedIn = true"
     />
+    <SortButtons
+      v-if="sensor.settings"
+      :edit-mode="editMode"
+      :sensor-id="sensor.id"
+    />
     <BookmarkButton
       :edit-mode="editMode"
       :is-dashboard="!!sensor.settings"
@@ -49,8 +54,9 @@ import BookmarkButton from '../BookmarkButton'
 import CurrentView from '../CurrentView'
 import Graph from '../Graph'
 import ModeButton from '../ModeButton'
+import SortButtons from '../SortButtons'
 import TimeButtons from '../TimeButtons'
-import CardHeader from '../CardHeader.vue'
+import CardHeader from '../CardHeader'
 
 export default {
   components: {
@@ -58,6 +64,7 @@ export default {
     CurrentView,
     Graph,
     ModeButton,
+    SortButtons,
     TimeButtons,
     CardHeader
   },

--- a/web-app/src/components/cards/Signal.vue
+++ b/web-app/src/components/cards/Signal.vue
@@ -37,6 +37,11 @@
       :zoomed-in="zoomedIn"
       @zoomed-in="zoomedIn = true"
       />
+    <SortButtons
+      v-if="sensor.settings"
+      :edit-mode="editMode"
+      :sensor-id="sensor.id"
+    />
     <BookmarkButton
       :edit-mode="editMode"
       :is-dashboard="!!sensor.settings"
@@ -52,8 +57,9 @@ import BookmarkButton from '../BookmarkButton'
 import CurrentView from '../CurrentView'
 import Graph from '../Graph'
 import ModeButton from '../ModeButton'
+import SortButtons from '../SortButtons'
 import TimeButtons from '../TimeButtons'
-import CardHeader from '../CardHeader.vue'
+import CardHeader from '../CardHeader'
 
 export default {
   components: {
@@ -61,6 +67,7 @@ export default {
     CurrentView,
     Graph,
     ModeButton,
+    SortButtons,
     TimeButtons,
     CardHeader
   },

--- a/web-app/src/components/cards/Signal.vue
+++ b/web-app/src/components/cards/Signal.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <ModeButton
-      :editMode="editMode"
+      :edit-mode="editMode"
       :value="mode"
       @input="setMode"
     />
@@ -12,7 +12,7 @@
       </div>
     </CardHeader>
     <TimeButtons
-      :editMode="editMode"
+      :edit-mode="editMode"
       :value="timeAgo"
       @input="setTimeAgo"
       :zoomed-in="zoomedIn"
@@ -37,7 +37,13 @@
       :zoomed-in="zoomedIn"
       @zoomed-in="zoomedIn = true"
       />
-    <BookmarkButton v-if="!sensor.settings" :mode="mode" :sensor-id="sensor.id" :time-ago="timeAgo" />
+    <BookmarkButton
+      :edit-mode="editMode"
+      :is-dashboard="!!sensor.settings"
+      :mode="mode"
+      :sensor-id="sensor.id"
+      :time-ago="timeAgo"
+    />
   </div>
 </template>
 

--- a/web-app/src/components/cards/Signal.vue
+++ b/web-app/src/components/cards/Signal.vue
@@ -1,13 +1,23 @@
 <template>
   <div>
-    <ModeButton :value="mode" @input="setMode" />
-    <CardHeader>
+    <ModeButton
+      :editMode="editMode"
+      :value="mode"
+      @input="setMode"
+    />
+    <CardHeader :editMode="editMode">
       <div>
         {{ sensor.label }}
         <span v-if="sensor.settings">- {{ sensor.station.label }}</span>
       </div>
     </CardHeader>
-    <TimeButtons :value="timeAgo" @input="setTimeAgo" :zoomed-in="zoomedIn" @reset-zoom="zoomedIn = false" />
+    <TimeButtons
+      :editMode="editMode"
+      :value="timeAgo"
+      @input="setTimeAgo"
+      :zoomed-in="zoomedIn"
+      @reset-zoom="zoomedIn = false"
+    />
     <CurrentView v-if="mode === 'current' && measurements.length" :measurements="measurements">
       <template v-slot:value1>
         {{ currentSignal }}dbm ({{ currentSignalQuality }})
@@ -49,6 +59,10 @@ export default {
     CardHeader
   },
   props: {
+    editMode: {
+      required: true,
+      type: Boolean
+    },
     sensor: {
       required: true,
       type: Object

--- a/web-app/src/components/cards/Temperature.vue
+++ b/web-app/src/components/cards/Temperature.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <ModeButton
-      :editMode="editMode"
+      :edit-mode="editMode"
       :value="mode"
       @input="setMode"
     />
@@ -12,7 +12,7 @@
       </div>
     </CardHeader>
     <TimeButtons
-      :editMode="editMode"
+      :edit-mode="editMode"
       :value="timeAgo"
       @input="setTimeAgo"
       :zoomed-in="zoomedIn"
@@ -34,7 +34,13 @@
       :zoomed-in="zoomedIn"
       @zoomed-in="zoomedIn = true"
     />
-    <BookmarkButton v-if="!sensor.settings" :mode="mode" :sensor-id="sensor.id" :time-ago="timeAgo" />
+    <BookmarkButton
+      :edit-mode="editMode"
+      :is-dashboard="!!sensor.settings"
+      :mode="mode"
+      :sensor-id="sensor.id"
+      :time-ago="timeAgo"
+    />
   </div>
 </template>
 

--- a/web-app/src/components/cards/Temperature.vue
+++ b/web-app/src/components/cards/Temperature.vue
@@ -1,13 +1,23 @@
 <template>
   <div>
-    <ModeButton :value="mode" @input="setMode" />
-    <CardHeader>
+    <ModeButton
+      :editMode="editMode"
+      :value="mode"
+      @input="setMode"
+    />
+    <CardHeader :editMode="editMode">
       <div>
         {{ sensor.label }}
         <span v-if="sensor.settings">- {{ sensor.station.label }}</span>
       </div>
     </CardHeader>
-    <TimeButtons :value="timeAgo" @input="setTimeAgo" :zoomed-in="zoomedIn" @reset-zoom="zoomedIn = false" />
+    <TimeButtons
+      :editMode="editMode"
+      :value="timeAgo"
+      @input="setTimeAgo"
+      :zoomed-in="zoomedIn"
+      @reset-zoom="zoomedIn = false"
+    />
     <CurrentView v-if="mode === 'current' && measurements.length" :measurements="measurements">
       <template v-slot:value1>{{ currentTemperature }}°{{ unitSymbol }}</template>
       <template v-slot:value2>{{ averageTemperature }}°{{ unitSymbol }}</template>
@@ -46,6 +56,10 @@ export default {
     CardHeader
   },
   props: {
+    editMode: {
+      required: true,
+      type: Boolean
+    },
     sensor: {
       required: true,
       type: Object

--- a/web-app/src/components/cards/Temperature.vue
+++ b/web-app/src/components/cards/Temperature.vue
@@ -34,6 +34,11 @@
       :zoomed-in="zoomedIn"
       @zoomed-in="zoomedIn = true"
     />
+    <SortButtons
+      v-if="sensor.settings"
+      :edit-mode="editMode"
+      :sensor-id="sensor.id"
+    />
     <BookmarkButton
       :edit-mode="editMode"
       :is-dashboard="!!sensor.settings"
@@ -49,8 +54,9 @@ import BookmarkButton from '../BookmarkButton'
 import CurrentView from '../CurrentView'
 import Graph from '../Graph'
 import ModeButton from '../ModeButton'
+import SortButtons from '../SortButtons'
 import TimeButtons from '../TimeButtons'
-import CardHeader from '../CardHeader.vue'
+import CardHeader from '../CardHeader'
 
 export default {
   components: {
@@ -58,6 +64,7 @@ export default {
     CurrentView,
     Graph,
     ModeButton,
+    SortButtons,
     TimeButtons,
     CardHeader
   },

--- a/web-app/src/components/cards/Voltage.vue
+++ b/web-app/src/components/cards/Voltage.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <ModeButton
-      :editMode="editMode"
+      :edit-mode="editMode"
       :modes="['percentage-chart', 'chart', 'current']" :value="mode"
       @input="setMode"
     />
@@ -12,7 +12,7 @@
       </div>
     </CardHeader>
     <TimeButtons
-      :editMode="editMode"
+      :edit-mode="editMode"
       :value="timeAgo"
       @input="setTimeAgo"
       :zoomed-in="zoomedIn"
@@ -37,8 +37,14 @@
       :options="chartOptions"
       :zoomed-in="zoomedIn"
       @zoomed-in="zoomedIn = true"
-      />
-    <BookmarkButton v-if="!sensor.settings" :mode="mode" :sensor-id="sensor.id" :time-ago="timeAgo" />
+    />
+    <BookmarkButton
+      :edit-mode="editMode"
+      :is-dashboard="!!sensor.settings"
+      :mode="mode"
+      :sensor-id="sensor.id"
+      :time-ago="timeAgo"
+    />
   </div>
 </template>
 

--- a/web-app/src/components/cards/Voltage.vue
+++ b/web-app/src/components/cards/Voltage.vue
@@ -38,6 +38,11 @@
       :zoomed-in="zoomedIn"
       @zoomed-in="zoomedIn = true"
     />
+    <SortButtons
+      v-if="sensor.settings"
+      :edit-mode="editMode"
+      :sensor-id="sensor.id"
+    />
     <BookmarkButton
       :edit-mode="editMode"
       :is-dashboard="!!sensor.settings"
@@ -53,8 +58,9 @@ import BookmarkButton from '../BookmarkButton'
 import CurrentView from '../CurrentView'
 import Graph from '../Graph'
 import ModeButton from '../ModeButton'
+import SortButtons from '../SortButtons'
 import TimeButtons from '../TimeButtons'
-import CardHeader from '../CardHeader.vue'
+import CardHeader from '../CardHeader'
 
 function voltsToPercent(volts) {
   const map = [
@@ -90,6 +96,7 @@ export default {
     CurrentView,
     Graph,
     ModeButton,
+    SortButtons,
     TimeButtons,
     CardHeader
   },

--- a/web-app/src/components/cards/Voltage.vue
+++ b/web-app/src/components/cards/Voltage.vue
@@ -1,13 +1,23 @@
 <template>
   <div>
-    <ModeButton :modes="['percentage-chart', 'chart', 'current']" :value="mode" @input="setMode" />
-    <CardHeader>
+    <ModeButton
+      :editMode="editMode"
+      :modes="['percentage-chart', 'chart', 'current']" :value="mode"
+      @input="setMode"
+    />
+    <CardHeader :editMode="editMode">
       <div>
         {{ sensor.label }}
         <span v-if="sensor.settings">- {{ sensor.station.label }}</span>
       </div>
     </CardHeader>
-    <TimeButtons :value="timeAgo" @input="setTimeAgo" :zoomed-in="zoomedIn" @reset-zoom="zoomedIn = false" />
+    <TimeButtons
+      :editMode="editMode"
+      :value="timeAgo"
+      @input="setTimeAgo"
+      :zoomed-in="zoomedIn"
+      @reset-zoom="zoomedIn = false"
+    />
     <CurrentView v-if="mode === 'current' && measurements.length" :measurements="measurements">
       <template v-slot:value1>
         {{ currentPercentage }}% ({{ currentVoltage | zeroPad }}v)
@@ -78,6 +88,10 @@ export default {
     CardHeader
   },
   props: {
+    editMode: {
+      required: true,
+      type: Boolean
+    },
     sensor: {
       required: true,
       type: Object

--- a/web-app/src/store/index.js
+++ b/web-app/src/store/index.js
@@ -10,8 +10,14 @@ export default new Vuex.Store({
   state: {
     dashboard: [],
     dashboardPromise: new Deferred(),
+    // Edit mode can be toggled on the dashboard
+    editMode: false,
+    // Left drawer opened or closed
     navDrawer: false,
+    // Text shown on the top toolbar. This
+    // gets set by the individual views.
     pageTitle: 'Weather Station App',
+    // Right drawer opened or closed
     preferencesDrawer: false,
     sensors: {},
     sensorPromises: {},
@@ -37,6 +43,9 @@ export default new Vuex.Store({
     },
     removeBookmark(state, sensorId) {
       Vue.set(state, 'dashboard', state.dashboard.filter(s => s.id !== sensorId))
+    },
+    setEditMode(state, bool) {
+      state.editMode = bool
     },
     setSensorMode(state, { sensorId, mode }) {
       const card = state.dashboard.find(c => c.id === sensorId)

--- a/web-app/src/store/index.js
+++ b/web-app/src/store/index.js
@@ -55,6 +55,32 @@ export default new Vuex.Store({
       const card = state.dashboard.find(c => c.id === sensorId)
       card.timeAgo = timeAgo
     },
+    moveSensorCard(state, { sensorId, direction }) {
+      // Take an element and move it over one space if it has the sensor ID in question
+      const reducer = (acc, el) => {
+        if (el.id === sensorId) {
+          acc.targetSensor = el
+        } else {
+          acc.arr.push(el)
+          if (acc.targetSensor) {
+            acc.arr.push(acc.targetSensor)
+            acc.targetSensor = null
+          }
+        }
+        return acc
+      }
+      if (direction === 'right') {
+        this.commit('setDashboard', state.dashboard.reduce(
+          reducer,
+          { arr: [], targetSensor: null }
+        ).arr)
+      } else {
+        this.commit('setDashboard', state.dashboard.reduceRight(
+          reducer,
+          { arr: [], targetSensor: null }
+        ).arr.reverse())
+      }
+    },
     setDashboard(state, dashboard) {
       Vue.set(state, 'dashboard', dashboard)
     },

--- a/web-app/src/views/Dashboard.vue
+++ b/web-app/src/views/Dashboard.vue
@@ -35,6 +35,7 @@
       </v-alert>
 
       <CardContainer
+        :edit-mode="editMode"
         :sensors="sensors"
         @change-mode="setSensorMode"
         @change-time-ago="setSensorTimeAgo"
@@ -68,6 +69,9 @@ export default {
     this.generateDashboard()
   },
   computed: {
+    editMode() {
+      return this.$store.state.editMode
+    },
     showPreferencesAlert: {
       get() {
         return this.$store.state.preferences.showAlert


### PR DESCRIPTION
**Closes #45**

- Hide buttons on small screens behind an "edit mode" that can be toggled from a button on the top toolbar
- Add trash can icon to dashboard to quickly remove sensor cards
- Add sort buttons to allow sorting dashboard sensor cards in the preferred order

**How to test:**

- Ensure cards can be added and removed from the dashboard
- All the card types can be toggled between different views without errors (ie toggle between graph view and the sparkline stats view)
- Sorting works as expected
- Buttons should all be hidden by default on small screens
- Buttons should always be visible on larger screens and no edit mode is present